### PR TITLE
Pass through the --include and --exclude params

### DIFF
--- a/dictionaryconverter
+++ b/dictionaryconverter
@@ -331,7 +331,7 @@ if __name__ == '__main__':
         if verbose:
             print('Converting "{}@{}"'.format(dictionary, dictpath))
     elif command == 'merge':
-        d = merge_dictionaries_in_dir(dictpath, module=module or None, verbose=verbose)
+        d = merge_dictionaries_in_dir(dictpath, module=module or None, include=args.include or None, exclude = args.exclude or None, verbose=verbose)
     else:
         sys.exit()
     if args.stringify:


### PR DESCRIPTION
The help documentation talks about using --include and --exclude, and these are useful now that SSP has split up quite a bit. However, the parameters are never passed through and so they don't actually work :). This patch fixes that.